### PR TITLE
Add new query for resolved calls (with receivers & generics)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,7 @@ name = "corpus-extractor"
 version = "0.1.0"
 dependencies = [
  "corpus-database",
+ "itertools",
  "lazy_static",
  "log",
  "log-derive",

--- a/database-dsl/src/generator/loader.rs
+++ b/database-dsl/src/generator/loader.rs
@@ -43,9 +43,10 @@ pub(super) fn generate_loader_functions(
                 *self.#name.borrow_mut() = Some(relation.into());
             }
         });
-        
+
         if let [key, value] = parameters.as_slice() {
-            let load_fn_name_as_map = syn::Ident::new(&format!("load_{}_as_map", name), Span::call_site());
+            let load_fn_name_as_map =
+                syn::Ident::new(&format!("load_{}_as_map", name), Span::call_site());
             let key = &key.typ;
             let value = &value.typ;
             function_tokens.extend(quote! {

--- a/database-dsl/src/generator/loader.rs
+++ b/database-dsl/src/generator/loader.rs
@@ -43,6 +43,17 @@ pub(super) fn generate_loader_functions(
                 *self.#name.borrow_mut() = Some(relation.into());
             }
         });
+        
+        if let [key, value] = parameters.as_slice() {
+            let load_fn_name_as_map = syn::Ident::new(&format!("load_{}_as_map", name), Span::call_site());
+            let key = &key.typ;
+            let value = &value.typ;
+            function_tokens.extend(quote! {
+                pub fn #load_fn_name_as_map(&self) -> std::collections::HashMap<#key, #value> {
+                    self.#load_fn_name().iter().copied().collect()
+                }
+            });
+        }
     }
     for table in &schema.interning_tables {
         let ast::InterningTable { name, key, value } = table;

--- a/database/src/schema.dl
+++ b/database/src/schema.dl
@@ -343,10 +343,8 @@ intern relative_def_paths<InternedString as RelativeDefId<u32>>;
 intern summary_keys<InternedString as SummaryId<u32>>;
 /// Interned ABI.
 intern abis<InternedString as Abi<u8>>;
-/// Definition paths is a globablly unique identifier of the definition.
+/// Definition paths is a globally unique identifier of the definition.
 intern def_paths<(Krate, CrateHash, RelativeDefId, DefPathHash, SummaryId) as DefPath<u64>>;
-/// Interned pretty descriptions for def paths.
-intern def_path_descriptions<InternedString as DefPathDescription<u32>>;
 /// A crate compiled with a specific configuration.
 intern builds<(Package, PackageVersion, Krate, CrateHash, Edition) as Build<u32>>;
 /// Interned span locations.
@@ -371,7 +369,7 @@ intern terminator_kinds<InternedString as TerminatorKind<u8>>;
 // Relations.
 
 relation def_path_span(def_path: DefPath, span: Span);
-relation def_path_description(def_path: DefPath, description: DefPathDescription);
+relation type_description(ty: Type, description: InternedString);
 /// The crate types associated with the build.
 relation build_crate_types(build: Build, crate_type: InternedString);
 /// The module that is the root of the AST tree.
@@ -499,7 +497,7 @@ relation terminators_drop_and_replace(block: BasicBlock, location: Type, value: 
 relation terminators_call(block: BasicBlock, call: auto FunctionCall, func: Operand, unsafety: Unsafety, abi: Abi, return_ty: Type, destination: BasicBlock, cleanup: BasicBlock, span: Span);
 relation terminators_call_arg(call: FunctionCall, index: CallArgIndex, arg: Operand);
 /// The called function or trait method.
-relation terminators_call_const_target(call: FunctionCall, def_path: DefPath);
+relation terminators_call_const_target(call: FunctionCall, def_path: DefPath, target_desc: InternedString);
 /// The self argument of the called method.
 relation terminators_call_const_target_self(call: FunctionCall, typ: Type);
 relation terminators_assert(block: BasicBlock, cond: Operand, expected: bool, target: BasicBlock, cleanup: BasicBlock);

--- a/database/src/schema.dl
+++ b/database/src/schema.dl
@@ -369,7 +369,7 @@ intern terminator_kinds<InternedString as TerminatorKind<u8>>;
 // Relations.
 
 relation def_path_span(def_path: DefPath, span: Span);
-relation type_description(ty: Type, description: InternedString);
+relation type_description(ty: Type, description: InternedString, generics: InternedString);
 /// The crate types associated with the build.
 relation build_crate_types(build: Build, crate_type: InternedString);
 /// The module that is the root of the AST tree.
@@ -497,7 +497,8 @@ relation terminators_drop_and_replace(block: BasicBlock, location: Type, value: 
 relation terminators_call(block: BasicBlock, call: auto FunctionCall, func: Operand, unsafety: Unsafety, abi: Abi, return_ty: Type, destination: BasicBlock, cleanup: BasicBlock, span: Span);
 relation terminators_call_arg(call: FunctionCall, index: CallArgIndex, arg: Operand);
 /// The called function or trait method.
-relation terminators_call_const_target(call: FunctionCall, def_path: DefPath, target_desc: InternedString);
+relation terminators_call_const_target(call: FunctionCall, def_path: DefPath);
+relation terminators_call_const_target_desc(call: FunctionCall, target: InternedString, function_generics: InternedString, type_generics: InternedString);
 /// The self argument of the called method.
 relation terminators_call_const_target_self(call: FunctionCall, typ: Type);
 relation terminators_assert(block: BasicBlock, cond: Operand, expected: bool, target: BasicBlock, cleanup: BasicBlock);

--- a/database/src/schema.dl
+++ b/database/src/schema.dl
@@ -501,6 +501,8 @@ relation terminators_call_const_target(call: FunctionCall, def_path: DefPath);
 relation terminators_call_const_target_desc(call: FunctionCall, target: InternedString, function_generics: InternedString, type_generics: InternedString);
 /// The self argument of the called method.
 relation terminators_call_const_target_self(call: FunctionCall, typ: Type);
+/// For calls originating from a macro, the path of the top macro in the backtrace that's from a different crate than the call site.
+relation terminators_call_macro_backtrace(call: FunctionCall, macro_path: InternedString);
 relation terminators_assert(block: BasicBlock, cond: Operand, expected: bool, target: BasicBlock, cleanup: BasicBlock);
 relation terminators_yield(block: BasicBlock, value: Operand, resume: BasicBlock, drop: BasicBlock);
 relation terminators_false_edges(block: BasicBlock, real_target: BasicBlock, imaginary_target: BasicBlock);

--- a/database/src/schema.dl
+++ b/database/src/schema.dl
@@ -345,6 +345,8 @@ intern summary_keys<InternedString as SummaryId<u32>>;
 intern abis<InternedString as Abi<u8>>;
 /// Definition paths is a globablly unique identifier of the definition.
 intern def_paths<(Krate, CrateHash, RelativeDefId, DefPathHash, SummaryId) as DefPath<u64>>;
+/// Interned pretty descriptions for def paths.
+intern def_path_descriptions<InternedString as DefPathDescription<u32>>;
 /// A crate compiled with a specific configuration.
 intern builds<(Package, PackageVersion, Krate, CrateHash, Edition) as Build<u32>>;
 /// Interned span locations.
@@ -369,6 +371,7 @@ intern terminator_kinds<InternedString as TerminatorKind<u8>>;
 // Relations.
 
 relation def_path_span(def_path: DefPath, span: Span);
+relation def_path_description(def_path: DefPath, description: DefPathDescription);
 /// The crate types associated with the build.
 relation build_crate_types(build: Build, crate_type: InternedString);
 /// The module that is the root of the AST tree.

--- a/extractor/Cargo.toml
+++ b/extractor/Cargo.toml
@@ -22,6 +22,7 @@ log = "0.4"
 log-derive = "0.4"
 lazy_static = "1.4"
 toml = "0.5.9"
+itertools = "0.10.5"
 
 [package.metadata.rust-analyzer]
 # This crate uses #[feature(rustc_private)]

--- a/extractor/src/lib.rs
+++ b/extractor/src/lib.rs
@@ -23,6 +23,7 @@ mod hir_visitor;
 mod mir_visitor;
 mod mirai_utils;
 mod table_filler;
+mod utils;
 
 use lazy_static::lazy_static;
 use rustc_data_structures::fx::FxHashSet;

--- a/extractor/src/mir_visitor.rs
+++ b/extractor/src/mir_visitor.rs
@@ -4,6 +4,7 @@
 
 use crate::converters::ConvertInto;
 use crate::table_filler::TableFiller;
+use crate::utils::*;
 use corpus_database::types;
 use rustc_hir as hir;
 use rustc_middle::mir;
@@ -453,6 +454,7 @@ impl<'a, 'b, 'tcx> MirVisitor<'a, 'b, 'tcx> {
                         match constant.literal.ty().kind() {
                             ty::TyKind::FnDef(target_id, substs) => {
                                 let generics = self.tcx.generics_of(*target_id);
+                                // TODO: store in db
                                 if generics.has_self {
                                     let self_ty = substs.type_at(0);
                                     let interned_type = self.filler.register_type(self_ty);
@@ -463,10 +465,13 @@ impl<'a, 'b, 'tcx> MirVisitor<'a, 'b, 'tcx> {
                                             interned_type,
                                         );
                                 }
+                                let desc = pretty_description(self.tcx, *target_id, substs);
+                                // TODO: identify receiver type in static dispatch
                                 let def_path = self.filler.resolve_def_id(*target_id);
                                 self.filler.tables.register_terminators_call_const_target(
                                     function_call,
                                     def_path,
+                                    desc
                                 );
                             }
                             ty::TyKind::FnPtr(_) => {

--- a/extractor/src/mir_visitor.rs
+++ b/extractor/src/mir_visitor.rs
@@ -454,7 +454,6 @@ impl<'a, 'b, 'tcx> MirVisitor<'a, 'b, 'tcx> {
                         match constant.literal.ty().kind() {
                             ty::TyKind::FnDef(target_id, substs) => {
                                 let generics = self.tcx.generics_of(*target_id);
-                                // TODO: store in db
                                 if generics.has_self {
                                     let self_ty = substs.type_at(0);
                                     let interned_type = self.filler.register_type(self_ty);

--- a/extractor/src/mir_visitor.rs
+++ b/extractor/src/mir_visitor.rs
@@ -449,6 +449,21 @@ impl<'a, 'b, 'tcx> MirVisitor<'a, 'b, 'tcx> {
                         interned_arg,
                     );
                 }
+
+                let top_foreign_macro = terminator
+                    .source_info
+                    .span
+                    .macro_backtrace()
+                    .flat_map(|element| element.macro_def_id)
+                    .filter(|macro_def| macro_def.krate != hir::def_id::LOCAL_CRATE)
+                    .last();
+                if let Some(def_id) = top_foreign_macro {
+                    let desc = pretty_description(self.tcx, def_id, &[]);
+                    self.filler
+                        .tables
+                        .register_terminators_call_macro_backtrace(function_call, desc.path);
+                }
+
                 match func {
                     mir::Operand::Constant(constant) => {
                         match constant.literal.ty().kind() {

--- a/extractor/src/mir_visitor.rs
+++ b/extractor/src/mir_visitor.rs
@@ -466,13 +466,19 @@ impl<'a, 'b, 'tcx> MirVisitor<'a, 'b, 'tcx> {
                                         );
                                 }
                                 let desc = pretty_description(self.tcx, *target_id, substs);
-                                // TODO: identify receiver type in static dispatch
                                 let def_path = self.filler.resolve_def_id(*target_id);
                                 self.filler.tables.register_terminators_call_const_target(
                                     function_call,
                                     def_path,
-                                    desc
                                 );
+                                self.filler
+                                    .tables
+                                    .register_terminators_call_const_target_desc(
+                                        function_call,
+                                        desc.path,
+                                        desc.function_generics,
+                                        desc.type_generics,
+                                    );
                             }
                             ty::TyKind::FnPtr(_) => {
                                 // Calling a function pointer.

--- a/extractor/src/mirai_utils.rs
+++ b/extractor/src/mirai_utils.rs
@@ -361,8 +361,6 @@ fn build_pretty_description(tcx: TyCtxt<'_>, def_id: DefId, desc: &mut String) {
     let def_path = tcx.def_path(def_id);
     if let Some(last_component) = def_path.data.last() {
         let parent = tcx.parent(def_id);
-        build_pretty_description(tcx, parent, desc);
-        desc.push_str("::");
 
         use DefPathData::*;
         match last_component.data {
@@ -372,16 +370,17 @@ fn build_pretty_description(tcx: TyCtxt<'_>, def_id: DefId, desc: &mut String) {
                 }
                 ty::ImplSubject::Trait(trait_ref) => {
                     desc.push_str(
-                        format!(
+                        &format!(
                             "<{} as {}>",
                             trait_ref.self_ty(),
                             trait_ref.print_only_trait_path()
-                        )
-                        .as_str(),
+                        ),
                     );
                 }
             },
             _ => {
+                build_pretty_description(tcx, parent, desc);
+                desc.push_str("::");
                 push_component_name(last_component.data, desc);
             }
         }

--- a/extractor/src/mirai_utils.rs
+++ b/extractor/src/mirai_utils.rs
@@ -293,10 +293,10 @@ pub fn summary_key_str(tcx: TyCtxt<'_>, def_id: DefId) -> Rc<String> {
         }
         if component.disambiguator != 0 {
             name.push('_');
-            
+
             let da = component.disambiguator.to_string();
             name.push_str(da.as_str());
-            
+
             if component.data == DefPathData::Impl {
                 let parent_def_id = tcx.parent(def_id);
                 if let Some(type_ns) = &type_ns {
@@ -331,60 +331,21 @@ pub fn is_foreign_contract(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
 }
 
 fn push_component_name(component_data: DefPathData, target: &mut String) {
+    target.push_str(component_name(&component_data));
+}
+
+pub fn component_name(component_data: &DefPathData) -> &str {
     use DefPathData::*;
     match component_data {
-        TypeNs(name) | ValueNs(name) | MacroNs(name) | LifetimeNs(name) => {
-            target.push_str(name.as_str());
-        }
-        _ => target.push_str(match component_data {
-            CrateRoot => "crate_root",
-            Impl => "implement",
-            ForeignMod => "foreign",
-            Use => "use",
-            GlobalAsm => "global_asm",
-            ClosureExpr => "closure",
-            Ctor => "ctor",
-            AnonConst => "constant",
-            ImplTrait => "implement_trait",
-            _ => unreachable!(),
-        }),
-    };
-}
-
-pub fn pretty_description(tcx: TyCtxt<'_>, def_id: DefId) -> String {
-    let mut desc = String::new();
-    build_pretty_description(tcx, def_id, &mut desc);
-    desc
-}
-
-fn build_pretty_description(tcx: TyCtxt<'_>, def_id: DefId, desc: &mut String) {
-    let def_path = tcx.def_path(def_id);
-    if let Some(last_component) = def_path.data.last() {
-        let parent = tcx.parent(def_id);
-
-        use DefPathData::*;
-        match last_component.data {
-            Impl => match tcx.impl_subject(def_id) {
-                ty::ImplSubject::Inherent(ty) => {
-                    desc.push_str(&ty.to_string());
-                }
-                ty::ImplSubject::Trait(trait_ref) => {
-                    desc.push_str(
-                        &format!(
-                            "<{} as {}>",
-                            trait_ref.self_ty(),
-                            trait_ref.print_only_trait_path()
-                        ),
-                    );
-                }
-            },
-            _ => {
-                build_pretty_description(tcx, parent, desc);
-                desc.push_str("::");
-                push_component_name(last_component.data, desc);
-            }
-        }
-    } else {
-        desc.push_str(tcx.crate_name(def_id.krate).as_str())
+        TypeNs(name) | ValueNs(name) | MacroNs(name) | LifetimeNs(name) => name.as_str(),
+        CrateRoot => "crate_root",
+        Impl => "implement",
+        ForeignMod => "foreign",
+        Use => "use",
+        GlobalAsm => "global_asm",
+        ClosureExpr => "closure",
+        Ctor => "ctor",
+        AnonConst => "constant",
+        ImplTrait => "implement_trait",
     }
 }

--- a/extractor/src/mirai_utils.rs
+++ b/extractor/src/mirai_utils.rs
@@ -294,24 +294,26 @@ pub fn summary_key_str(tcx: TyCtxt<'_>, def_id: DefId) -> Rc<String> {
         if component.disambiguator != 0 {
             name.push('_');
 
-            let da = component.disambiguator.to_string();
-            name.push_str(da.as_str());
-
             if component.data == DefPathData::Impl {
                 let parent_def_id = tcx.parent(def_id);
                 if let Some(type_ns) = &type_ns {
                     let def_kind = tcx.def_kind(parent_def_id);
                     use rustc_hir::def::DefKind::*;
-                    name.push('_');
+
                     if type_ns == "num"
                         && (def_kind == Struct || def_kind == Union || def_kind == Enum)
                     {
                         append_mangled_type(&mut name, tcx.type_of(parent_def_id), tcx);
-                    } else {
-                        name.push_str(&type_ns);
+                        continue;
                     }
                 }
+                if let Some(type_ns) = &type_ns {
+                    name.push_str(&type_ns);
+                    continue;
+                }
             }
+            let da = component.disambiguator.to_string();
+            name.push_str(da.as_str());
         }
     }
     Rc::new(name)

--- a/extractor/src/mirai_utils.rs
+++ b/extractor/src/mirai_utils.rs
@@ -352,12 +352,8 @@ fn push_component_name(component_data: DefPathData, target: &mut String) {
 }
 
 pub fn pretty_description(tcx: TyCtxt<'_>, def_id: DefId) -> String {
-    println!();
-    let def_path = tcx.def_path(def_id);
-    println!("{:?}", def_path);
     let mut desc = String::new();
     build_pretty_description(tcx, def_id, &mut desc);
-    println!("pretty desc: {}", desc);
     desc
 }
 

--- a/extractor/src/mirai_utils.rs
+++ b/extractor/src/mirai_utils.rs
@@ -293,25 +293,25 @@ pub fn summary_key_str(tcx: TyCtxt<'_>, def_id: DefId) -> Rc<String> {
         }
         if component.disambiguator != 0 {
             name.push('_');
+            
+            let da = component.disambiguator.to_string();
+            name.push_str(da.as_str());
+            
             if component.data == DefPathData::Impl {
                 let parent_def_id = tcx.parent(def_id);
                 if let Some(type_ns) = &type_ns {
                     let def_kind = tcx.def_kind(parent_def_id);
                     use rustc_hir::def::DefKind::*;
+                    name.push('_');
                     if type_ns == "num"
                         && (def_kind == Struct || def_kind == Union || def_kind == Enum)
                     {
                         append_mangled_type(&mut name, tcx.type_of(parent_def_id), tcx);
-                        continue;
+                    } else {
+                        name.push_str(&type_ns);
                     }
                 }
-                if let Some(type_ns) = &type_ns {
-                    name.push_str(&type_ns);
-                    continue;
-                }
             }
-            let da = component.disambiguator.to_string();
-            name.push_str(da.as_str());
         }
     }
     Rc::new(name)
@@ -331,11 +331,10 @@ pub fn is_foreign_contract(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
 }
 
 fn push_component_name(component_data: DefPathData, target: &mut String) {
-    use std::ops::Deref;
     use DefPathData::*;
     match component_data {
         TypeNs(name) | ValueNs(name) | MacroNs(name) | LifetimeNs(name) => {
-            target.push_str(name.as_str().deref());
+            target.push_str(name.as_str());
         }
         _ => target.push_str(match component_data {
             CrateRoot => "crate_root",

--- a/extractor/src/table_filler.rs
+++ b/extractor/src/table_filler.rs
@@ -111,13 +111,16 @@ impl<'a, 'tcx> TableFiller<'a, 'tcx> {
     fn insert_new_type_into_table(&mut self, kind: &str, typ: ty::Ty<'tcx>) -> types::Type {
         assert!(!self.type_registry.contains_key(&typ));
         let (interned_type,) = self.tables.register_types(kind.to_string());
-        let desc = match typ.ty_adt_def() {
-            Some(def) => pretty_description(self.tcx, def.did(), &[]),
-            None => typ.to_string(),
+        let (desc, generics) = match typ.kind() {
+            ty::Adt(def, substs) => {
+                let desc = pretty_description(self.tcx, def.did(), substs);
+                (desc.path, desc.type_generics)
+            }
+            _ => (typ.to_string(), Default::default()),
         };
         //println!("orig: {}", typ.to_string());
         //println!("desc: {}", desc);
-        self.tables.register_type_description(interned_type, desc);
+        self.tables.register_type_description(interned_type, desc, generics);
         self.type_registry.insert(typ, interned_type);
         interned_type
     }

--- a/extractor/src/table_filler.rs
+++ b/extractor/src/table_filler.rs
@@ -65,7 +65,7 @@ impl<'a, 'tcx> TableFiller<'a, 'tcx> {
             def_path_hash,
             summary_key_str_value,
         );
-        
+
         if def_id.is_local() {
             // This will panic if def_id is non-local
             let def_span = self.tcx.def_span(def_id);
@@ -118,7 +118,8 @@ impl<'a, 'tcx> TableFiller<'a, 'tcx> {
             }
             _ => (typ.to_string(), Default::default()),
         };
-        self.tables.register_type_description(interned_type, desc, generics);
+        self.tables
+            .register_type_description(interned_type, desc, generics);
         self.type_registry.insert(typ, interned_type);
         interned_type
     }

--- a/extractor/src/table_filler.rs
+++ b/extractor/src/table_filler.rs
@@ -4,6 +4,7 @@
 
 use crate::converters::ConvertInto;
 use crate::mirai_utils;
+use crate::utils::pretty_description;
 use corpus_database::{tables::Tables, types};
 use rustc_hir::{self as hir, HirId};
 use rustc_middle::hir::map::Map as HirMap;
@@ -110,9 +111,12 @@ impl<'a, 'tcx> TableFiller<'a, 'tcx> {
     fn insert_new_type_into_table(&mut self, kind: &str, typ: ty::Ty<'tcx>) -> types::Type {
         assert!(!self.type_registry.contains_key(&typ));
         let (interned_type,) = self.tables.register_types(kind.to_string());
-        // get crate of type
-        //let crate_num = typ.ty_adt_def().unwrap().did.krate;
-        let desc = typ.to_string();
+        let desc = match typ.ty_adt_def() {
+            Some(def) => pretty_description(self.tcx, def.did(), &[]),
+            None => typ.to_string(),
+        };
+        //println!("orig: {}", typ.to_string());
+        //println!("desc: {}", desc);
         self.tables.register_type_description(interned_type, desc);
         self.type_registry.insert(typ, interned_type);
         interned_type

--- a/extractor/src/table_filler.rs
+++ b/extractor/src/table_filler.rs
@@ -64,6 +64,10 @@ impl<'a, 'tcx> TableFiller<'a, 'tcx> {
             def_path_hash,
             summary_key_str_value,
         );
+        
+        let pretty_description = mirai_utils::pretty_description(self.tcx, def_id);
+        self.tables.register_def_path_description(def_path, pretty_description);
+        
         if def_id.is_local() {
             // This will panic if def_id is non-local
             let def_span = self.tcx.def_span(def_id);

--- a/extractor/src/table_filler.rs
+++ b/extractor/src/table_filler.rs
@@ -118,8 +118,6 @@ impl<'a, 'tcx> TableFiller<'a, 'tcx> {
             }
             _ => (typ.to_string(), Default::default()),
         };
-        //println!("orig: {}", typ.to_string());
-        //println!("desc: {}", desc);
         self.tables.register_type_description(interned_type, desc, generics);
         self.type_registry.insert(typ, interned_type);
         interned_type

--- a/extractor/src/table_filler.rs
+++ b/extractor/src/table_filler.rs
@@ -65,9 +65,6 @@ impl<'a, 'tcx> TableFiller<'a, 'tcx> {
             summary_key_str_value,
         );
         
-        let pretty_description = mirai_utils::pretty_description(self.tcx, def_id);
-        self.tables.register_def_path_description(def_path, pretty_description);
-        
         if def_id.is_local() {
             // This will panic if def_id is non-local
             let def_span = self.tcx.def_span(def_id);
@@ -113,6 +110,10 @@ impl<'a, 'tcx> TableFiller<'a, 'tcx> {
     fn insert_new_type_into_table(&mut self, kind: &str, typ: ty::Ty<'tcx>) -> types::Type {
         assert!(!self.type_registry.contains_key(&typ));
         let (interned_type,) = self.tables.register_types(kind.to_string());
+        // get crate of type
+        //let crate_num = typ.ty_adt_def().unwrap().did.krate;
+        let desc = typ.to_string();
+        self.tables.register_type_description(interned_type, desc);
         self.type_registry.insert(typ, interned_type);
         interned_type
     }

--- a/extractor/src/utils.rs
+++ b/extractor/src/utils.rs
@@ -38,20 +38,20 @@ fn build_pretty_description(
             Impl => {
                 match tcx.impl_subject(def_id) {
                     ty::ImplSubject::Inherent(ty) => {
-						let parent_substs = if substs.is_empty() {
-							&[]
-						} else {
-							// as seen in rustc_middle::ty::print::Printer::default_print_def_path
-							let generics = tcx.generics_of(def_id);
-							&substs[..generics.parent_count.min(substs.len())]
-						};
-						// get DefId of the type
-						if let Some(ty_def) = ty.ty_adt_def() {
-							build_pretty_description(tcx, ty_def.did(), parent_substs, desc);
-						} else {
-							let ty_desc = ty.to_string();
-							desc.push_str(&ty_desc);
-						}
+                        let parent_substs = if substs.is_empty() {
+                            &[]
+                        } else {
+                            // as seen in rustc_middle::ty::print::Printer::default_print_def_path
+                            let generics = tcx.generics_of(def_id);
+                            &substs[..generics.parent_count.min(substs.len())]
+                        };
+                        // get DefId of the type
+                        if let Some(ty_def) = ty.ty_adt_def() {
+                            build_pretty_description(tcx, ty_def.did(), parent_substs, desc);
+                        } else {
+                            let ty_desc = ty.to_string();
+                            desc.push_str(&ty_desc);
+                        }
                     }
                     ty::ImplSubject::Trait(_trait_ref) => {
                         desc.push_str("<APPARENTLY NOT UNREACHABLE>");
@@ -66,7 +66,7 @@ fn build_pretty_description(
                 let parent_substs = if substs.is_empty() {
                     &[]
                 } else {
-					// as seen in rustc_middle::ty::print::Printer::default_print_def_path
+                    // as seen in rustc_middle::ty::print::Printer::default_print_def_path
                     let generics = tcx.generics_of(def_id);
                     &substs[..generics.parent_count.min(substs.len())]
                 };
@@ -77,23 +77,23 @@ fn build_pretty_description(
                 //println!("back to {:?}", def_key.disambiguated_data.data);
             }
         }
-		
-		if !substs.is_empty() {
-			let generics = tcx.generics_of(def_id);
-			//println!("generics: {:?}", generics);
 
-			let start_index = if generics.has_self { 1 } else { 0 };
-			let params: Vec<_> = generics
-				.params
-				.iter()
-				.filter(|p| p.index >= start_index)
+        if !substs.is_empty() {
+            let generics = tcx.generics_of(def_id);
+            //println!("generics: {:?}", generics);
+
+            let start_index = if generics.has_self { 1 } else { 0 };
+            let params: Vec<_> = generics
+                .params
+                .iter()
+                .filter(|p| p.index >= start_index)
                 .filter(|p| matches!(p.kind, ty::GenericParamDefKind::Type { .. }))
-				.collect();
+                .collect();
 
-			if !params.is_empty() {
-				desc.push('<');
-				for generic in params {
-					let subst = substs[generic.index as usize];
+            if !params.is_empty() {
+                desc.push('<');
+                for generic in params {
+                    let subst = substs[generic.index as usize];
                     let subst_ty = match subst.unpack() {
                         ty::subst::GenericArgKind::Type(ty) => ty,
                         _ => unreachable!(), // such params would be filtered out above
@@ -107,10 +107,10 @@ fn build_pretty_description(
                     };
                     println!("generic: {} for {}", subst_desc, generic.name);
                     desc.push_str(&subst_desc);
-				}
-				desc.push('>');
-			}
-		}
+                }
+                desc.push('>');
+            }
+        }
     } else {
         //println!("root");
         desc.push_str(tcx.crate_name(def_id.krate).as_str())

--- a/extractor/src/utils.rs
+++ b/extractor/src/utils.rs
@@ -105,7 +105,7 @@ fn build_pretty_description(
                         }
                         _ => subst_ty.to_string(),
                     };
-                    println!("generic: {} for {}", subst_desc, generic.name);
+                    //println!("generic: {} for {}", subst_desc, generic.name);
                     desc.push_str(&subst_desc);
                 }
                 desc.push('>');

--- a/extractor/src/utils.rs
+++ b/extractor/src/utils.rs
@@ -16,7 +16,7 @@ pub fn pretty_description<'t>(
     //    tcx.def_path_str_with_substs(def_id, substs)
     //);
     build_pretty_description(tcx, def_id, substs, &mut desc);
-    println!("pretty_description for {} is {:?}", tcx.def_path_str_with_substs(def_id, substs), desc);
+    //println!("pretty_description for {} is {:?}", tcx.def_path_str_with_substs(def_id, substs), desc);
     //println!();
     desc
 }
@@ -48,7 +48,7 @@ pub fn pretty_type_description<'t>(tcx: TyCtxt<'t>, ty: &ty::Ty<'t>) -> String {
         }
         _ => ty.to_string(),
     };
-    println!("type description {} for type: {}", desc, ty);
+    //println!("type description {} for type: {}", desc, ty);
     desc
 }
 
@@ -146,11 +146,11 @@ fn build_pretty_description<'t>(
             if !resolved_generics.is_empty() {
                 let dest = match tcx.def_kind(def_id) {
                     DefKind::Fn | DefKind::AssocFn => {
-                        println!("function generics: {}", resolved_generics);
+                        //println!("function generics: {}", resolved_generics);
                         &mut desc.function_generics
                     }
-                    kind => {
-                        println!("type generics for {:?}: {}", kind, resolved_generics);
+                    _kind => {
+                        //println!("type generics for {:?}: {}", _kind, resolved_generics);
                         &mut desc.type_generics
                     }
                 };

--- a/extractor/src/utils.rs
+++ b/extractor/src/utils.rs
@@ -1,0 +1,106 @@
+use rustc_hir::def_id::DefId;
+use rustc_hir::definitions::DefPathData;
+use rustc_middle::ty::{self, GenericArg, TyCtxt};
+
+pub fn pretty_description<'t>(
+    tcx: TyCtxt<'t>,
+    def_id: DefId,
+    substs: &'t [GenericArg<'t>],
+) -> String {
+    let mut desc = String::new();
+    //let path = tcx.def_path(def_id);
+    //println!();
+    //println!(
+    //    "building for {}",
+    //    tcx.def_path_str_with_substs(def_id, substs)
+    //);
+    build_pretty_description(tcx, def_id, substs, &mut desc);
+    //println!("pretty_description: {}", desc);
+    //println!();
+    desc
+}
+
+fn build_pretty_description(
+    tcx: TyCtxt<'_>,
+    def_id: DefId,
+    substs: &[GenericArg],
+    desc: &mut String,
+) {
+    let def_key = tcx.def_key(def_id);
+    //println!("data: {:?}", def_key.disambiguated_data.data);
+    if let Some(parent) = def_key.parent {
+        //println!("desc: {}, last_component: {:?}", desc, last_component);
+        //let generics = tcx.generics_of(def_id);
+        //println!("generics: {:?}", generics);
+
+        use DefPathData::*;
+        match def_key.disambiguated_data.data {
+            Impl => {
+                match tcx.impl_subject(def_id) {
+                    ty::ImplSubject::Inherent(ty) => {
+						let parent_substs = if substs.is_empty() {
+							&[]
+						} else {
+							// as seen in rustc_middle::ty::print::Printer::default_print_def_path
+							let generics = tcx.generics_of(def_id);
+							&substs[..generics.parent_count.min(substs.len())]
+						};
+						// get DefId of the type
+						if let Some(ty_def) = ty.ty_adt_def() {
+							build_pretty_description(tcx, ty_def.did(), parent_substs, desc);
+						} else {
+							let ty_desc = ty.to_string();
+							desc.push_str(&ty_desc);
+						}
+                    }
+                    ty::ImplSubject::Trait(_trait_ref) => {
+                        desc.push_str("<APPARENTLY NOT UNREACHABLE>");
+                    }
+                }
+            }
+            data => {
+                let parent_id = DefId {
+                    krate: def_id.krate,
+                    index: parent,
+                };
+                let parent_substs = if substs.is_empty() {
+                    &[]
+                } else {
+					// as seen in rustc_middle::ty::print::Printer::default_print_def_path
+                    let generics = tcx.generics_of(def_id);
+                    &substs[..generics.parent_count.min(substs.len())]
+                };
+                build_pretty_description(tcx, parent_id, parent_substs, desc);
+                desc.push_str("::");
+                desc.push_str(crate::mirai_utils::component_name(&data));
+
+                //println!("back to {:?}", def_key.disambiguated_data.data);
+            }
+        }
+		
+		if !substs.is_empty() {
+			let generics = tcx.generics_of(def_id);
+			//println!("generics: {:?}", generics);
+
+			let start_index = if generics.has_self { 1 } else { 0 };
+			let params: Vec<_> = generics
+				.params
+				.iter()
+				.filter(|p| p.index >= start_index)
+				.collect();
+
+			if !params.is_empty() {
+				desc.push('<');
+				for generic in params {
+					let subst = substs[generic.index as usize];
+					//println!("generic: {} for {}", subst, generic.name);
+					desc.push_str(&subst.to_string());
+				}
+				desc.push('>');
+			}
+		}
+    } else {
+        //println!("root");
+        desc.push_str(tcx.crate_name(def_id.krate).as_str())
+    }
+}

--- a/manager/src/queries/mod.rs
+++ b/manager/src/queries/mod.rs
@@ -8,6 +8,7 @@ mod function_size;
 mod non_tree_types;
 mod prepare_builds;
 mod prepare_items;
+mod resolved_calls;
 mod size;
 mod traits;
 mod types;
@@ -57,6 +58,7 @@ pub fn run_query(
         "build-files" => build_files::query(&loader, &report_path.join("build-files")),
         "traits" => traits::query(&loader, &report_path.join("traits")),
         "types" => types::query(&loader, &report_path.join("types")),
+        "resolved-calls" => resolved_calls::query(&loader, &report_path.join("resolved-calls")),
         "unsafe-types" => unsafe_types::query(&loader, &report_path.join("unsafe-types")),
         "unsafe-block-groups" => {
             unsafe_block_groups::query(&loader, &report_path.join("unsafe-block-groups"))

--- a/manager/src/queries/resolved_calls.rs
+++ b/manager/src/queries/resolved_calls.rs
@@ -14,12 +14,12 @@ use std::path::Path;
 /// - the crate of the call site and of the called function
 ///
 /// The produced table is deduplicated, with each row instead saying how many times it occurs.
-/// 
+///
 /// As an example, for a call in crate `foo` to `Option::map` mapping an optional string slice (`&str`) to an owned `String`, these would be:
 /// - empty strings for the receiver and its generics, since this is not part of a trait.
 /// - `core::option::Option<T>::map`, `&str`, and `String, $fn`
 /// - `foo` and `core` (the crates involved)
-/// 
+///
 /// Note that function references & closures are always reported as `$fn`.
 /// Further, and perhaps unexpectedly, the path to the target includes generic parameters, but they are simply what the corresponding `impl` block calls them, not the actual types used---these are found in the type generics (here, `&str` is the value of `T`).
 pub fn query(loader: &Loader, report_path: &Path) {

--- a/manager/src/queries/resolved_calls.rs
+++ b/manager/src/queries/resolved_calls.rs
@@ -7,6 +7,21 @@ use itertools::Itertools;
 use std::collections::HashMap;
 use std::path::Path;
 
+/// Gathers data on all calls made.
+/// This query reports, for each call, descriptions of:
+/// - the receiver of a trait method (if applicable) & its generics
+/// - the call's target method & the generics of its type & function
+/// - the crate of the call site and of the called function
+///
+/// The produced table is deduplicated, with each row instead saying how many times it occurs.
+/// 
+/// As an example, for a call in crate `foo` to `Option::map` mapping an optional string slice (`&str`) to an owned `String`, these would be:
+/// - empty strings for the receiver and its generics, since this is not part of a trait.
+/// - `core::option::Option<T>::map`, `&str`, and `String, $fn`
+/// - `foo` and `core` (the crates involved)
+/// 
+/// Note that function references & closures are always reported as `$fn`.
+/// Further, and perhaps unexpectedly, the path to the target includes generic parameters, but they are simply what the corresponding `impl` block calls them, not the actual types used---these are found in the type generics (here, `&str` is the value of `T`).
 pub fn query(loader: &Loader, report_path: &Path) {
     let call_target = loader.load_terminators_call_const_target_as_map();
     let call_target_self = loader.load_terminators_call_const_target_self_as_map();

--- a/manager/src/queries/resolved_calls.rs
+++ b/manager/src/queries/resolved_calls.rs
@@ -71,8 +71,10 @@ pub fn query(loader: &Loader, report_path: &Path) {
                     (&strings[desc], &strings[generics])
                 },
             );
-            
-            let macro_path = call_target_macro.get(&call).map_or("", |path| &strings[*path]);
+
+            let macro_path = call_target_macro
+                .get(&call)
+                .map_or("", |path| &strings[*path]);
 
             Some((
                 receiver_name,

--- a/manager/src/queries/resolved_calls.rs
+++ b/manager/src/queries/resolved_calls.rs
@@ -1,0 +1,121 @@
+//! Report information about calls in our codebase.
+//! For trait methods whose receiver is statically known, report this resolved type rather than the trait.
+
+use super::utils::DefPathResolver;
+use crate::write_csv;
+use corpus_database::tables::Loader;
+use corpus_database::{types::*, InterningTable};
+use std::cell::Ref;
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+pub fn query(loader: &Loader, report_path: &Path) {
+    let terminators_call_const_target: HashMap<_, _> = loader
+        .load_terminators_call_const_target()
+        .iter()
+        .copied()
+        .collect();
+    let terminators_call_const_target_self: HashMap<_, _> = loader
+        .load_terminators_call_const_target_self()
+        .iter()
+        .copied()
+        .collect();
+    let strings = loader.load_strings();
+    let abis = loader.load_abis();
+    let trait_items = loader.load_trait_items();
+    let trait_items: HashSet<_> = trait_items
+        .iter()
+        .map(|(_trait_id, def_path, _defaultness)| def_path)
+        .collect();
+    let def_path_descriptions = loader.load_def_path_descriptions();
+    let pretty_descriptions: HashMap<_, _> = loader
+        .load_def_path_description()
+        .iter()
+        .map(|&(def_path, description)| (def_path, &strings[def_path_descriptions[description]]))
+        .collect();
+
+    let type_name_resolver = TypeNameResolver::new(loader);
+
+    let all_calls = loader.load_terminators_call();
+    let all_calls = all_calls.iter().map(
+        |&(_block, call, func, _unsafety, abi, _return_ty, _destination, _cleanup, _span)| {
+            // TODO: crate of call site
+            let (call_target, is_trait_item) = if let Some(target) =
+                terminators_call_const_target.get(&call)
+            {
+                (
+                    pretty_descriptions[target].as_ref(),
+                    trait_items.contains(target),
+                )
+            } else {
+                ("non-const", false)
+            };
+            let call_receiver_name = terminators_call_const_target_self
+                .get(&call)
+                .map_or_else(|| "".to_string(), |typ| type_name_resolver.resolve(typ));
+            (
+                call,
+                func,
+                strings[abis[abi]].to_string(),
+                call_receiver_name,
+                call_target,
+                is_trait_item,
+            )
+        },
+    );
+    write_csv!(report_path, all_calls);
+}
+
+struct TypeNameResolver<'b> {
+    def_path_resolver: DefPathResolver<'b>,
+    types: HashMap<Type, TyKind>,
+    types_adt_def: HashMap<Type, DefPath>,
+    types_primitive: HashMap<Type, TyPrimitive>,
+    types_ref: HashMap<Type, (Type, Mutability)>,
+    type_kinds: Ref<'b, InterningTable<TyKind, InternedString>>,
+    strings: Ref<'b, InterningTable<InternedString, String>>,
+}
+
+impl<'b> TypeNameResolver<'b> {
+    fn new(loader: &'b Loader) -> Self {
+        Self {
+            def_path_resolver: DefPathResolver::new(loader),
+            types: loader.load_types().iter().copied().collect(),
+            types_adt_def: loader
+                .load_types_adt_def()
+                .iter()
+                .copied()
+                .map(|(typ, def_path, _kind, _c_repr, _is_phantom)| (typ, def_path))
+                .collect(),
+            types_primitive: loader.load_types_primitive().iter().copied().collect(),
+            types_ref: loader
+                .load_types_ref()
+                .iter()
+                .copied()
+                .map(|(typ, ty, mutability)| (typ, (ty, mutability)))
+                .collect(),
+            type_kinds: loader.load_type_kinds(),
+            strings: loader.load_strings(),
+        }
+    }
+
+    fn resolve(&self, typ: &Type) -> String {
+        if let Some(adt_def) = self.types_adt_def.get(&typ) {
+            let (_crate_name, _, _def_path, _, summary) = self.def_path_resolver.resolve(*adt_def);
+            summary.replace(".", "::")
+        } else if let Some(primitive) = self.types_primitive.get(&typ) {
+            format!("$primitive::{}", primitive.to_string().to_lowercase())
+        } else if let Some((ty, mutability)) = self.types_ref.get(&typ) {
+            let mutability = match mutability {
+                Mutability::Mutable => "&mut ",
+                Mutability::Immutable => "&",
+                Mutability::Const => "&const ",
+                Mutability::Unknown => "&?",
+            };
+            format!("{}{}", mutability, self.resolve(ty))
+        } else {
+            let kind = self.type_kinds[self.types[typ]];
+            format!("$other::{}", self.strings[kind])
+        }
+    }
+}

--- a/manager/src/queries/resolved_calls.rs
+++ b/manager/src/queries/resolved_calls.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 /// - the receiver of a trait method (if applicable) & its generics
 /// - the call's target method & the generics of its type & function
 /// - the crate of the call site and of the called function
+/// - if applicable, the first macro involved in the call stack that is not from the calling crate
 ///
 /// The produced table is deduplicated, with each row instead saying how many times it occurs.
 ///

--- a/manager/src/queries/resolved_calls.rs
+++ b/manager/src/queries/resolved_calls.rs
@@ -33,6 +33,7 @@ pub fn query(loader: &Loader, report_path: &Path) {
             (call, (desc, function_generics, type_generics))
         })
         .collect();
+    let call_target_macro = loader.load_terminators_call_macro_backtrace_as_map();
 
     let strings = loader.load_strings();
     let def_paths = loader.load_def_paths();
@@ -69,6 +70,8 @@ pub fn query(loader: &Loader, report_path: &Path) {
                     (&strings[desc], &strings[generics])
                 },
             );
+            
+            let macro_path = call_target_macro.get(&call).map_or("", |path| &strings[*path]);
 
             Some((
                 receiver_name,
@@ -78,6 +81,7 @@ pub fn query(loader: &Loader, report_path: &Path) {
                 &strings[function_generics],
                 caller_crate_name,
                 target_crate_name,
+                macro_path,
             ))
         },
     );
@@ -88,7 +92,7 @@ pub fn query(loader: &Loader, report_path: &Path) {
     });
     let all_calls = counts
         .iter()
-        .map(|((a, b, c, d, e, f, g), count)| (a, b, c, d, e, f, g, count));
+        .map(|((a, b, c, d, e, f, g, h), count)| (a, b, c, d, e, f, g, h, count));
 
     // sort for much better gzip compression
     let all_calls: Vec<_> = all_calls
@@ -97,7 +101,7 @@ pub fn query(loader: &Loader, report_path: &Path) {
 
     let cross_crate_calls = all_calls
         .iter()
-        .filter(|&(_, _, _, _, _, caller_crate, target_crate, _)| caller_crate != target_crate);
+        .filter(|&(_, _, _, _, _, caller_crate, target_crate, _, _)| caller_crate != target_crate);
     write_csv!(report_path, cross_crate_calls);
 
     write_csv!(report_path, all_calls);

--- a/manager/src/queries/resolved_calls.rs
+++ b/manager/src/queries/resolved_calls.rs
@@ -3,14 +3,14 @@
 
 use crate::write_csv;
 use corpus_database::tables::Loader;
-use std::collections::{HashMap, HashSet};
+use itertools::Itertools;
+use std::collections::HashMap;
 use std::path::Path;
 
 pub fn query(loader: &Loader, report_path: &Path) {
-    let terminators_call_const_target = loader.load_terminators_call_const_target_as_map();
-    let terminators_call_const_target_self =
-        loader.load_terminators_call_const_target_self_as_map();
-    let terminators_call_const_target_desc: HashMap<_, _> = loader
+    let call_target = loader.load_terminators_call_const_target_as_map();
+    let call_target_self = loader.load_terminators_call_const_target_self_as_map();
+    let call_target_desc: HashMap<_, _> = loader
         .load_terminators_call_const_target_desc()
         .iter()
         .copied()
@@ -18,53 +18,44 @@ pub fn query(loader: &Loader, report_path: &Path) {
             (call, (desc, function_generics, type_generics))
         })
         .collect();
+
     let strings = loader.load_strings();
-    let trait_items = loader.load_trait_items();
-    let trait_items: HashSet<_> = trait_items
-        .iter()
-        .map(|(_trait_id, def_path, _defaultness)| def_path)
-        .collect();
     let def_paths = loader.load_def_paths();
     let crate_names = loader.load_crate_names();
+
     let type_descriptions: HashMap<_, _> = loader
         .load_type_description()
         .iter()
         .copied()
         .map(|(ty, desc, generics)| (ty, (desc, generics)))
         .collect();
+
     let basic_block_def_paths: HashMap<_, _> = loader
         .load_basic_blocks()
         .iter()
         .map(|&(bb, def_path, _kind)| (bb, def_path))
         .collect();
 
-    //let type_name_resolver = TypeNameResolver::new(loader);
-
     let all_calls = loader.load_terminators_call();
     let all_calls = all_calls.iter().filter_map(
-        |&(block, call, func, _unsafety, _abi, _return_ty, _destination, _cleanup, _span)| {
+        |&(block, call, _func, _unsafety, _abi, _return_ty, _destination, _cleanup, _span)| {
+            let target = call_target.get(&call)?; // none for function pointers
+            let (target_desc, function_generics, type_generics) = call_target_desc[&call];
+
             let (caller_crate, _, _, _, _) = def_paths[basic_block_def_paths[&block]];
             let caller_crate_name = &strings[crate_names[caller_crate]];
-
-            let target = terminators_call_const_target.get(&call)?; // none for function pointers
-            let (target_desc, function_generics, type_generics) =
-                terminators_call_const_target_desc[&call];
             let (target_crate, _, _, _, _) = def_paths[*target];
             let target_crate_name = &strings[crate_names[target_crate]];
-            let is_trait_item = trait_items.contains(target);
 
-            let (receiver_name, receiver_generics) =
-                terminators_call_const_target_self.get(&call).map_or_else(
-                    || ("", ""),
-                    |typ| {
-                        let (desc, generics) = type_descriptions[typ];
-                        (&strings[desc], &strings[generics])
-                    },
-                );
+            let (receiver_name, receiver_generics) = call_target_self.get(&call).map_or_else(
+                || ("", ""),
+                |typ| {
+                    let (desc, generics) = type_descriptions[typ];
+                    (&strings[desc], &strings[generics])
+                },
+            );
 
             Some((
-                call,
-                func,
                 receiver_name,
                 receiver_generics,
                 &strings[target_desc],
@@ -72,65 +63,23 @@ pub fn query(loader: &Loader, report_path: &Path) {
                 &strings[function_generics],
                 caller_crate_name,
                 target_crate_name,
-                is_trait_item,
             ))
         },
     );
+
+    let counts: HashMap<_, i32> = all_calls.fold(HashMap::new(), |mut counts, row| {
+        *counts.entry(row).or_insert(0) += 1;
+        counts
+    });
+    let all_calls = counts.iter().map(|((a, b, c, d, e, f, g), count)| (a, b, c, d, e, f, g, count));
+
+    // sort for much better gzip compression
+    let all_calls: Vec<_> = all_calls.sorted_by_key(|(_, _, target, ..)| target.clone()).collect();
+    
+    let cross_crate_calls = all_calls.iter().filter(|&(_, _, _, _, _, caller_crate, target_crate, _)| {
+        caller_crate != target_crate
+    });
+    write_csv!(report_path, cross_crate_calls);
+    
     write_csv!(report_path, all_calls);
 }
-
-/*
-struct TypeNameResolver<'b> {
-    def_path_resolver: DefPathResolver<'b>,
-    types: HashMap<Type, TyKind>,
-    types_adt_def: HashMap<Type, DefPath>,
-    types_primitive: HashMap<Type, TyPrimitive>,
-    types_ref: HashMap<Type, (Type, Mutability)>,
-    type_kinds: Ref<'b, InterningTable<TyKind, InternedString>>,
-    strings: Ref<'b, InterningTable<InternedString, String>>,
-}
-
-impl<'b> TypeNameResolver<'b> {
-    fn new(loader: &'b Loader) -> Self {
-        Self {
-            def_path_resolver: DefPathResolver::new(loader),
-            types: loader.load_types().iter().copied().collect(),
-            types_adt_def: loader
-                .load_types_adt_def()
-                .iter()
-                .copied()
-                .map(|(typ, def_path, _kind, _c_repr, _is_phantom)| (typ, def_path))
-                .collect(),
-            types_primitive: loader.load_types_primitive().iter().copied().collect(),
-            types_ref: loader
-                .load_types_ref()
-                .iter()
-                .copied()
-                .map(|(typ, ty, mutability)| (typ, (ty, mutability)))
-                .collect(),
-            type_kinds: loader.load_type_kinds(),
-            strings: loader.load_strings(),
-        }
-    }
-
-    fn resolve(&self, typ: &Type) -> String {
-        if let Some(adt_def) = self.types_adt_def.get(&typ) {
-            let (_crate_name, _, _def_path, _, summary) = self.def_path_resolver.resolve(*adt_def);
-            summary.replace(".", "::")
-        } else if let Some(primitive) = self.types_primitive.get(&typ) {
-            format!("$primitive::{}", primitive.to_string().to_lowercase())
-        } else if let Some((ty, mutability)) = self.types_ref.get(&typ) {
-            let mutability = match mutability {
-                Mutability::Mutable => "&mut ",
-                Mutability::Immutable => "&",
-                Mutability::Const => "&const ",
-                Mutability::Unknown => "&?",
-            };
-            format!("{}{}", mutability, self.resolve(ty))
-        } else {
-            let kind = self.type_kinds[self.types[typ]];
-            format!("$other::{}", self.strings[kind])
-        }
-    }
-}
-*/

--- a/manager/src/queries/resolved_calls.rs
+++ b/manager/src/queries/resolved_calls.rs
@@ -71,15 +71,19 @@ pub fn query(loader: &Loader, report_path: &Path) {
         *counts.entry(row).or_insert(0) += 1;
         counts
     });
-    let all_calls = counts.iter().map(|((a, b, c, d, e, f, g), count)| (a, b, c, d, e, f, g, count));
+    let all_calls = counts
+        .iter()
+        .map(|((a, b, c, d, e, f, g), count)| (a, b, c, d, e, f, g, count));
 
     // sort for much better gzip compression
-    let all_calls: Vec<_> = all_calls.sorted_by_key(|(_, _, target, ..)| target.clone()).collect();
-    
-    let cross_crate_calls = all_calls.iter().filter(|&(_, _, _, _, _, caller_crate, target_crate, _)| {
-        caller_crate != target_crate
-    });
+    let all_calls: Vec<_> = all_calls
+        .sorted_by_key(|(_, _, target, ..)| target.clone())
+        .collect();
+
+    let cross_crate_calls = all_calls
+        .iter()
+        .filter(|&(_, _, _, _, _, caller_crate, target_crate, _)| caller_crate != target_crate);
     write_csv!(report_path, cross_crate_calls);
-    
+
     write_csv!(report_path, all_calls);
 }

--- a/manager/src/queries/unsafe_block_calls.rs
+++ b/manager/src/queries/unsafe_block_calls.rs
@@ -13,9 +13,12 @@ fn report_unsafe_block_calls(loader: &Loader, report_path: &Path) {
     let span_resolver = SpanResolver::new(loader);
 
     let def_paths = loader.load_def_paths();
-    let terminators_call_const_target = loader.load_terminators_call_const_target();
-    let terminators_call_const_target: HashMap<_, _> =
-        terminators_call_const_target.iter().copied().collect();
+    let terminators_call_const_target: HashMap<_, _> = loader
+        .load_terminators_call_const_target()
+        .iter()
+        .copied()
+        .map(|(id, target, _desc)| (id, target))
+        .collect();
     let crate_names = loader.load_crate_names();
     let relative_def_paths = loader.load_relative_def_paths();
     let strings = loader.load_strings();
@@ -85,9 +88,12 @@ fn report_unsafe_block_calls(loader: &Loader, report_path: &Path) {
 /// Report information about all calls in our codebase.
 fn report_all_calls(loader: &Loader, report_path: &Path) {
     let def_paths = loader.load_def_paths();
-    let terminators_call_const_target = loader.load_terminators_call_const_target();
-    let terminators_call_const_target: HashMap<_, _> =
-        terminators_call_const_target.iter().copied().collect();
+    let terminators_call_const_target: HashMap<_, _> = loader
+        .load_terminators_call_const_target()
+        .iter()
+        .copied()
+        .map(|(id, target, _desc)| (id, target))
+        .collect();
     let strings = loader.load_strings();
     let abis = loader.load_abis();
     let trait_items = loader.load_trait_items();

--- a/manager/src/queries/unsafe_block_calls.rs
+++ b/manager/src/queries/unsafe_block_calls.rs
@@ -13,12 +13,7 @@ fn report_unsafe_block_calls(loader: &Loader, report_path: &Path) {
     let span_resolver = SpanResolver::new(loader);
 
     let def_paths = loader.load_def_paths();
-    let terminators_call_const_target: HashMap<_, _> = loader
-        .load_terminators_call_const_target()
-        .iter()
-        .copied()
-        .map(|(id, target, _desc)| (id, target))
-        .collect();
+    let terminators_call_const_target = loader.load_terminators_call_const_target_as_map();
     let crate_names = loader.load_crate_names();
     let relative_def_paths = loader.load_relative_def_paths();
     let strings = loader.load_strings();
@@ -88,12 +83,7 @@ fn report_unsafe_block_calls(loader: &Loader, report_path: &Path) {
 /// Report information about all calls in our codebase.
 fn report_all_calls(loader: &Loader, report_path: &Path) {
     let def_paths = loader.load_def_paths();
-    let terminators_call_const_target: HashMap<_, _> = loader
-        .load_terminators_call_const_target()
-        .iter()
-        .copied()
-        .map(|(id, target, _desc)| (id, target))
-        .collect();
+    let terminators_call_const_target = loader.load_terminators_call_const_target_as_map();
     let strings = loader.load_strings();
     let abis = loader.load_abis();
     let trait_items = loader.load_trait_items();

--- a/manager/src/queries/unsafe_block_groups.rs
+++ b/manager/src/queries/unsafe_block_groups.rs
@@ -6,7 +6,7 @@ use crate::write_csv;
 use corpus_database::tables::Loader;
 use corpus_queries_derive::datapond_query;
 use log::info;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::convert::TryInto;
 use std::path::Path;
 
@@ -148,7 +148,7 @@ fn report_non_const_call_targets(loader: &Loader, report_path: &Path) {
     let const_calls: HashSet<_> = loader
         .load_terminators_call_const_target()
         .iter()
-        .map(|(call, _def_path, _desc)| *call)
+        .map(|(call, _def_path)| *call)
         .collect();
     let build_resolver = BuildResolver::new(loader);
     let strings = loader.load_strings();
@@ -184,12 +184,7 @@ fn report_non_const_call_targets(loader: &Loader, report_path: &Path) {
 /// 3. Dynamic calls on trait objects.
 /// 4. Calls of closures.
 fn report_const_call_targets(loader: &Loader, report_path: &Path) {
-    let const_calls_map: HashMap<_, _> = loader
-        .load_terminators_call_const_target()
-        .iter()
-        .copied()
-        .map(|(id, target, _desc)| (id, target))
-        .collect();
+    let const_calls_map = loader.load_terminators_call_const_target_as_map();
     let def_path_resolver = DefPathResolver::new(loader);
     let build_resolver = BuildResolver::new(loader);
     let strings = loader.load_strings();

--- a/manager/src/queries/unsafe_block_groups.rs
+++ b/manager/src/queries/unsafe_block_groups.rs
@@ -148,7 +148,7 @@ fn report_non_const_call_targets(loader: &Loader, report_path: &Path) {
     let const_calls: HashSet<_> = loader
         .load_terminators_call_const_target()
         .iter()
-        .map(|(call, _def_path)| *call)
+        .map(|(call, _def_path, _desc)| *call)
         .collect();
     let build_resolver = BuildResolver::new(loader);
     let strings = loader.load_strings();
@@ -187,7 +187,8 @@ fn report_const_call_targets(loader: &Loader, report_path: &Path) {
     let const_calls_map: HashMap<_, _> = loader
         .load_terminators_call_const_target()
         .iter()
-        .cloned()
+        .copied()
+        .map(|(id, target, _desc)| (id, target))
         .collect();
     let def_path_resolver = DefPathResolver::new(loader);
     let build_resolver = BuildResolver::new(loader);


### PR DESCRIPTION
As part of [my thesis](https://ethz.ch/content/dam/ethz/special-interest/infk/chair-program-method/pm/documents/Education/Theses/Julian_Dunskus_MS_Description.pdf) under @Aurel300, I'm using qrates to evaluate which methods are most commonly used. There's several changes I've made to get the data I want:

- I've built general functions to gather meaningful descriptions for types and `DefPath`s/`DefId`s, optionally incorporating provided `substs`.
- Using these, I've added two new relations to the database:
	- `type_description`, which provides the aforementioned description and, separately, a description of generic arguments, for a `ty::Ty`
	- `terminators_call_const_target_desc`, which similarly provides descriptions for the target of a call, and separately the generics on the function and those on the type, if any.
- I added a little [convenience function](https://github.com/juliand665/qrates/blob/90e83f5471ee8d692c3933153185dca5d5bfb600/database-dsl/src/generator/loader.rs#L47-L56) for loading relations as `HashMap`s when they only involve two values, which honestly may not be worth the extra complexity? Feel free to discuss.
- I added a new query, `resolved-calls`, that is fundamentally similar to `report_all_calls` from the `unsafe-block-calls` query, though it's less focused on unsafety and more on the type information for the receiver and generics etc. It prints all this new data I'm collecting. Notably:
	- This gathers, for each call, descriptions of: the receiver (if any) & its generics, the target & its function & type generics, and the crate of the call site and of the called function.
	- The entries that would be outputted to the CSV are first deduplicated and instead stored with their number of occurrences, to reduce how much data is produced. (This takes the output for the top 1000 crates from 524 MB to 39 MB.)
	- These deduplicated entries are further sorted, in order to maximize compressibility using Gzip. (The aforementioned output gzips down to 4.8 MB; would be 10.6 MB without sorting.)

Using this, I've been putting together a Jupyter notebook to evaluate all this data. It would probably make sense to include this in the repo?
It also feels like I should be documenting the output of my query somewhere; not sure if there's already a place for that?

I'm submitting this as a draft PR because I'm not yet sure that I've ironed out all the kinks with this format, so I might still make some changes to e.g. generic descriptions if I find a problem with the current output as I use it. I would eventually like to have data on all the crates, though, so this PR will be finalized within the next few weeks.